### PR TITLE
malloc(0) returns null or valid pointer

### DIFF
--- a/src/sdk/buffer.c
+++ b/src/sdk/buffer.c
@@ -57,7 +57,14 @@ BUFFER_HANDLE BUFFER_create(const unsigned char* source, size_t size)
         }
         else
         {
-            result->buffer = (unsigned char*)malloc(size);
+            if(!size)
+            {
+                result->buffer = NULL;
+            }
+            else
+            {
+                result->buffer = (unsigned char*)malloc(size);
+            }
             if (result->buffer == NULL)
             {
                 /*Codes_SRS_BUFFER_02_003: [If allocating memory fails, then BUFFER_create shall return NULL.]*/


### PR DESCRIPTION
Feather M0 WIFI board, malloc(0) returns a valid pointer while on ESP8266 it returns NULL. So when sending empty cloud-to-device message, it succeeded on Feather M0 but failed on ESP8266 with error BUFFER_create failed. In our sdk, the right behavior for malloc(0) should return NULL rather than a valid pointer.